### PR TITLE
(2P) Limit templates for new pages only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
 node_modules
 .cache
+.idea
 wp-js-plugin-starter.zip

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -13,10 +13,7 @@
  * Retrieves a URL to a file in the plugin's directory.
  *
  * @param  string $path Relative path of the desired file.
- *
  * @return string       Fully qualified URL pointing to the desired file.
- *
- * @since 1.0.0
  */
 function wp_js_plugin_starter_url( $path ) {
 	return plugins_url( $path, __FILE__ );
@@ -34,7 +31,7 @@ add_action( 'init', 'page_templates_register' );
 function page_templates_enqueue() {
 	$screen = get_current_screen();
 
-	// return early if we don't meet conditions to show templates
+	// Return early if we don't meet conditions to show templates.
 	if ( 'page' !== $screen->id || 'add' !== $screen->action ) {
 		return;
 	}

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -32,6 +32,13 @@ function page_templates_register() {
 add_action( 'init', 'page_templates_register' );
 
 function page_templates_enqueue() {
+    $screen = get_current_screen();
+    
+    // return early if we don't meet conditions to show templates
+    if ( $screen->id !== 'page' || $screen->action !== 'add' ) {
+        return;
+    }
+    
     wp_enqueue_script( 'plugin-sidebar-js' );
 }
 add_action( 'enqueue_block_editor_assets', 'page_templates_enqueue' );

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -35,7 +35,7 @@ function page_templates_enqueue() {
 	$screen = get_current_screen();
 
 	// return early if we don't meet conditions to show templates
-	if ( $screen->id !== 'page' || $screen->action !== 'add' ) {
+	if ( 'page' !== $screen->id || 'add' !== $screen->action ) {
 		return;
 	}
 

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -9,7 +9,7 @@
  * @package wp-js-plugin-starter
  */
 
- /**
+/**
  * Retrieves a URL to a file in the plugin's directory.
  *
  * @param  string $path Relative path of the desired file.
@@ -23,22 +23,22 @@ function wp_js_plugin_starter_url( $path ) {
 }
 
 function page_templates_register() {
-    wp_register_script(
-        'plugin-sidebar-js',
-        wp_js_plugin_starter_url( 'dist/index.js' ),
-        array( 'wp-plugins', 'wp-edit-post', 'wp-element' )
-    );
+	wp_register_script(
+		'plugin-sidebar-js',
+		wp_js_plugin_starter_url( 'dist/index.js' ),
+		array( 'wp-plugins', 'wp-edit-post', 'wp-element' )
+	);
 }
 add_action( 'init', 'page_templates_register' );
 
 function page_templates_enqueue() {
-    $screen = get_current_screen();
-    
-    // return early if we don't meet conditions to show templates
-    if ( $screen->id !== 'page' || $screen->action !== 'add' ) {
-        return;
-    }
-    
-    wp_enqueue_script( 'plugin-sidebar-js' );
+	$screen = get_current_screen();
+
+	// return early if we don't meet conditions to show templates
+	if ( $screen->id !== 'page' || $screen->action !== 'add' ) {
+		return;
+	}
+
+	wp_enqueue_script( 'plugin-sidebar-js' );
 }
 add_action( 'enqueue_block_editor_assets', 'page_templates_enqueue' );


### PR DESCRIPTION
This PR limits our plugin to show only when you create a new Page.

- Confirm you see dialog for new Page
- Confirm you don't see it for:
  - editing existing Page
  - new Post
  - editing Post

Fixes #4 