### PR TITLE
(5P) Add template list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,17 @@
 ( function( wp ) {
     const registerPlugin = wp.plugins.registerPlugin;
     const createElement = wp.element.createElement;
-    const { Modal, Button } = wp.components;
+    const { Modal, Button, RadioControl } = wp.components;
     const { withState } = wp.compose;
     
-    const insertTemplate = () => {
-        fetch('https://www.mocky.io/v2/5cd3fb89350000de307a5211')
+    const insertTemplate = template => {
+        console.log( 'Using template', template );
+
+        // set title
+        wp.data.dispatch('core/editor').editPost({title: template.title});
+        
+        // load content
+        fetch( template.contentUrl )
         .then( res => res.json() )
         .then( data => {
             const template = data.body.content;
@@ -16,21 +22,36 @@
     
     const PageTemplateModal = withState( {
         isOpen: true,
-    } )( ( { isOpen, setState } ) => (
+        isLoading: false,
+        selectedTemplate: 'home',
+        templates: {
+            home: { title: 'Home', slug: 'home', contentUrl: 'https://www.mocky.io/v2/5cd3fb89350000de307a5211' },
+            menu: { title: 'Menu', slug: 'menu', contentUrl: 'https://www.mocky.io/v2/5cd3fb89350000de307a5211' },
+            contact: { title: 'Contact Us', slug: 'contact', contentUrl: 'https://www.mocky.io/v2/5cd3fb89350000de307a5211' },
+        },
+    } )( ( { isOpen, selectedTemplate, templates, setState } ) => (
         <div>
             { isOpen && (
                 <Modal
                     title="Select Page Template"
                     onRequestClose={ () => setState( { isOpen: false } ) }>
-                    <Button
-                        isDefault
-                        onClick={ () => {
+                    <RadioControl
+                        label="Template"
+                        selected={ selectedTemplate }
+                        options={ Object.values( templates ).map( template => ( { label: template.title, value: template.slug } ) ) }
+                        onChange={ ( selectedTemplate ) => { setState( { selectedTemplate } ) } }
+                    />
+                    <div>
+                        <Button isDefault isLarge onClick={ () => setState( { isOpen: false } ) }>
+                            Start with blank page
+                        </Button>
+                        <Button isPrimary isLarge onClick={ () => {
                             setState( { isOpen: false } );
-                            insertTemplate();
-                        }}
-                    >
-                        This One!
-                    </Button>
+                            insertTemplate( templates[ selectedTemplate ] );
+                        } }>
+                            Use Template
+                        </Button>
+                    </div>
                 </Modal>
             ) }
         </div>


### PR DESCRIPTION
Fixes #3 

I've used `RadioControl` for the first iteration. Do we want something more custom or is it good for now?

I've also added a list of templates (mocked) and I've added an action that sets the title of newly created page to the same one as the template (like "Home" or "Contact").

Test:
- create a new page
- try new radio template selector
- try both buttons
  - "blank" should just dismiss dialog
  - "use" should set the post title to the template name and pull content - for now it's the same for all of them

It's not styled well as of now. We can address that later once we have a more clear vision of that dialog.