### PR TITLE
Replace placeholders in templates and titles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import replacePlaceholders from './utils/replace-placeholders';
+
 ( function( wp ) {
     const registerPlugin = wp.plugins.registerPlugin;
     const createElement = wp.element.createElement;
@@ -8,13 +10,13 @@
         console.log( 'Using template', template );
 
         // set title
-        wp.data.dispatch('core/editor').editPost({title: template.title});
+        wp.data.dispatch('core/editor').editPost({title: replacePlaceholders( template.title ) } );
         
         // load content
         fetch( template.contentUrl )
         .then( res => res.json() )
         .then( data => {
-            const template = data.body.content;
+            const template = replacePlaceholders( data.body.content );
             const blocks = wp.blocks.parse(template);
             wp.data.dispatch('core/editor').insertBlocks(blocks);
         }).catch( err => console.log(err) );
@@ -25,9 +27,9 @@
         isLoading: false,
         selectedTemplate: 'home',
         templates: {
-            home: { title: 'Home', slug: 'home', contentUrl: 'https://www.mocky.io/v2/5cd3fb89350000de307a5211' },
-            menu: { title: 'Menu', slug: 'menu', contentUrl: 'https://www.mocky.io/v2/5cd3fb89350000de307a5211' },
-            contact: { title: 'Contact Us', slug: 'contact', contentUrl: 'https://www.mocky.io/v2/5cd3fb89350000de307a5211' },
+            home: { title: 'Home', slug: 'home', contentUrl: 'https://www.mocky.io/v2/5ce525112e00006900f83afe' },
+            menu: { title: 'Menu', slug: 'menu', contentUrl: 'https://www.mocky.io/v2/5ce525112e00006900f83afe' },
+            contact: { title: 'Contact Us', slug: 'contact', contentUrl: 'https://www.mocky.io/v2/5ce525112e00006900f83afe' },
         },
     } )( ( { isOpen, selectedTemplate, templates, setState } ) => (
         <div>

--- a/src/utils/replace-placeholders.js
+++ b/src/utils/replace-placeholders.js
@@ -1,0 +1,23 @@
+const __ = a => a;
+
+const PLACEHOLDER_DEFAULTS = {
+    'Address': '123 Main St',
+    'Phone': '555-555-5555',
+    'CompanyName': __( 'Your Company Name' ),
+};
+
+const KEY_MAP = {
+    'CompanyName': 'title',
+    'Address': 'address',
+    'Phone': 'phone',
+};
+
+const replacePlaceholders = ( pageContent, siteInformation = {} ) => {
+    return pageContent.replace( /{{(\w+)}}/g, ( match, placeholder ) => {
+        const defaultValue = PLACEHOLDER_DEFAULTS[ placeholder ];
+        const key = KEY_MAP[ placeholder ];
+        return siteInformation[ key ] || defaultValue || placeholder;
+    } );
+};
+
+export default replacePlaceholders;


### PR DESCRIPTION
Fixes #21 

I've updated our mock api to include all possible placeholders. For now, they will get replaced by their respective default value. Let's connect it to real data separately.

To test: 
- confirm you cannot see any `{{placeholders}}` once the template imports into the editor
- You should see "Your Company Title" in the main headline