### PR TITLE
Add text placeholder support with real data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,24 @@
 import replacePlaceholders from './utils/replace-placeholders';
 
-( function( wp ) {
+( function( wp, config = {} ) {
     const registerPlugin = wp.plugins.registerPlugin;
     const createElement = wp.element.createElement;
     const { Modal, Button, RadioControl } = wp.components;
     const { withState } = wp.compose;
     
+    const { siteInformation = {}, vertical = null } = config;
+    
     const insertTemplate = template => {
         console.log( 'Using template', template );
 
         // set title
-        wp.data.dispatch('core/editor').editPost({title: replacePlaceholders( template.title ) } );
+        wp.data.dispatch('core/editor').editPost({title: replacePlaceholders( template.title, siteInformation ) } );
         
         // load content
         fetch( template.contentUrl )
         .then( res => res.json() )
         .then( data => {
-            const template = replacePlaceholders( data.body.content );
+            const template = replacePlaceholders( data.body.content, siteInformation );
             const blocks = wp.blocks.parse(template);
             wp.data.dispatch('core/editor').insertBlocks(blocks);
         }).catch( err => console.log(err) );
@@ -65,4 +67,4 @@ import replacePlaceholders from './utils/replace-placeholders';
             );
         }
     } );
-} )( window.wp );
+} )( window.wp, window.starterPageTemplatesConfig );

--- a/starter-page-templates.php
+++ b/starter-page-templates.php
@@ -44,15 +44,15 @@ function page_templates_enqueue() {
 	}
 
 	wp_enqueue_script( 'starter-page-templates' );
-	
+
 	$default_info = array(
 		'title' => get_bloginfo( 'name' ),
 	);
-	$site_info = get_site_option( 'site_contact_info', array() );
-	
+	$site_info    = get_site_option( 'site_contact_info', array() );
+
 	$config = array(
 		'siteInformation' => array_merge( $default_info, $site_info ),
-		'vertical' => get_site_option( 'site_vertical' ),
+		'vertical'        => get_site_option( 'site_vertical' ),
 	);
 	wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 }

--- a/starter-page-templates.php
+++ b/starter-page-templates.php
@@ -44,5 +44,16 @@ function page_templates_enqueue() {
 	}
 
 	wp_enqueue_script( 'starter-page-templates' );
+	
+	$default_info = array(
+		'title' => get_bloginfo( 'name' ),
+	);
+	$site_info = get_site_option( 'site_contact_info', array() );
+	
+	$config = array(
+		'siteInformation' => array_merge( $default_info, $site_info ),
+		'vertical' => get_site_option( 'site_vertical' ),
+	);
+	wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 }
 add_action( 'enqueue_block_editor_assets', 'page_templates_enqueue' );


### PR DESCRIPTION
I have used [`wp_localize_script`](https://codex.wordpress.org/Function_Reference/wp_localize_script) to pass config to our frontend. As part of that, I've added site information there and I also noticed a vertical name in site options so I passed it too (might be useful or just removed later if not).

I'm not 100% sure how to test the functionality fully, as I'm not aware of any site with `site_contact_info` option. What definitely works is the site title - which will get inserted into the main headline.

Builds on top of #22 
Closes #21 