### PR TITLE
(3P) Add individual page templates based on vertical starter site

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,9 @@ import TemplateSelectorControl from './components/template-selector-control';
         isLoading: false,
         selectedTemplate: 'home',
         templates: {
-            home: { title: 'Home', slug: 'home', contentUrl: 'https://www.mocky.io/v2/5ce525112e00006900f83afe', imgSrc: 'https://via.placeholder.com/200x180', },
-            menu: { title: 'Menu', slug: 'menu', contentUrl: 'https://www.mocky.io/v2/5ce525112e00006900f83afe', imgSrc: 'https://via.placeholder.com/200x180', },
-            contact: { title: 'Contact Us', slug: 'contact', contentUrl: 'https://www.mocky.io/v2/5ce525112e00006900f83afe', imgSrc: 'https://via.placeholder.com/200x180', },
+            home: { title: 'Home', slug: 'home', contentUrl: 'https://www.mocky.io/v2/5ce680d73300009801731614', imgSrc: 'https://via.placeholder.com/200x180', },
+            menu: { title: 'Menu', slug: 'menu', contentUrl: 'https://www.mocky.io/v2/5ce681173300006600731617', imgSrc: 'https://via.placeholder.com/200x180', },
+            contact: { title: 'Contact Us', slug: 'contact', contentUrl: 'https://www.mocky.io/v2/5ce681763300004b3573161a', imgSrc: 'https://via.placeholder.com/200x180', },
         },
     } )( ( { isOpen, selectedTemplate, templates, setState } ) => (
         <div>


### PR DESCRIPTION
## This PR
- Adds three distinct page templates for the demo based on the existing vertical starter site wp-PasQ7B-h.

## Screenshots

<img width="1257" alt="Screen Shot 2019-05-23 at 13 27 11" src="https://user-images.githubusercontent.com/1562646/58249241-9b745100-7d5e-11e9-8783-38df3b631e48.png">
<img width="1259" alt="Screen Shot 2019-05-23 at 13 27 31" src="https://user-images.githubusercontent.com/1562646/58249242-9b745100-7d5e-11e9-91b7-02afff549007.png">
<img width="1264" alt="Screen Shot 2019-05-23 at 13 27 48" src="https://user-images.githubusercontent.com/1562646/58249243-9c0ce780-7d5e-11e9-9ffd-37a6760b6938.png">
