### PR TITLE
(3P) Move template list from JS to PHP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
+import { keyBy } from 'lodash';
 
 import TemplateSelectorControl from './components/template-selector-control';
 
@@ -9,31 +10,23 @@ import TemplateSelectorControl from './components/template-selector-control';
     const { Modal, Button } = wp.components;
     const { withState } = wp.compose;
     
-    const { siteInformation = {}, vertical = null } = config;
+    const { siteInformation = {}, templates = [] } = config;
     
     const insertTemplate = template => {
         // set title
         wp.data.dispatch('core/editor').editPost({title: replacePlaceholders( template.title, siteInformation ) } );
         
         // load content
-        fetch( template.contentUrl )
-        .then( res => res.json() )
-        .then( data => {
-            const template = replacePlaceholders( data.body.content, siteInformation );
-            const blocks = wp.blocks.parse(template);
-            wp.data.dispatch('core/editor').insertBlocks(blocks);
-        }).catch( err => console.log(err) );
+        const templateString = replacePlaceholders( template.content, siteInformation );
+        const blocks = wp.blocks.parse( templateString );
+        wp.data.dispatch('core/editor').insertBlocks( blocks );
     };
     
     const PageTemplateModal = withState( {
         isOpen: true,
         isLoading: false,
         selectedTemplate: 'home',
-        templates: {
-            home: { title: 'Home', slug: 'home', contentUrl: 'https://www.mocky.io/v2/5ce680d73300009801731614', imgSrc: 'https://via.placeholder.com/200x180', },
-            menu: { title: 'Menu', slug: 'menu', contentUrl: 'https://www.mocky.io/v2/5ce681173300006600731617', imgSrc: 'https://via.placeholder.com/200x180', },
-            contact: { title: 'Contact Us', slug: 'contact', contentUrl: 'https://www.mocky.io/v2/5ce681763300004b3573161a', imgSrc: 'https://via.placeholder.com/200x180', },
-        },
+        templates: keyBy( templates, 'slug' ),
     } )( ( { isOpen, selectedTemplate, templates, setState } ) => (
         <div>
             { isOpen && (
@@ -57,7 +50,7 @@ import TemplateSelectorControl from './components/template-selector-control';
                                         templates={ Object.values( templates ).map( template => ( {
                                              label: template.title, 
                                              value: template.slug,
-                                             preview: template.imgSrc
+                                             preview: template.preview,
                                          } ) ) }
                                         onChange={ ( selectedTemplate ) => { setState( { selectedTemplate } ) } }
                                     />

--- a/starter-page-templates.php
+++ b/starter-page-templates.php
@@ -52,7 +52,26 @@ function page_templates_enqueue() {
 
 	$config = array(
 		'siteInformation' => array_merge( $default_info, $site_info ),
-		'vertical'        => get_site_option( 'site_vertical' ),
+		'templates'       => array(
+			array(
+				'title'   => 'Home',
+				'slug' 	  => 'home',
+				'content' => json_decode( file_get_contents( 'http://www.mocky.io/v2/5ce680d73300009801731614' ) )->body->content,
+				'preview' => 'https://via.placeholder.com/200x180',
+			),
+            array(
+				'title'   => 'Menu',
+				'slug' 	  => 'menu',
+				'content' => json_decode( file_get_contents( 'http://www.mocky.io/v2/5ce681173300006600731617' ) )->body->content,
+				'preview' => 'https://via.placeholder.com/200x180',
+			),
+            array(
+				'title'   => 'Contact Us',
+				'slug' 	  => 'contact',
+				'content' => json_decode( file_get_contents( 'http://www.mocky.io/v2/5ce681763300004b3573161a' ) )->body->content,
+				'preview' => 'https://via.placeholder.com/200x180',
+			),
+		),
 	);
 	wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 }

--- a/starter-page-templates.php
+++ b/starter-page-templates.php
@@ -55,20 +55,20 @@ function page_templates_enqueue() {
 		'templates'       => array(
 			array(
 				'title'   => 'Home',
-				'slug' 	  => 'home',
-				'content' => json_decode( file_get_contents( 'http://www.mocky.io/v2/5ce680d73300009801731614' ) )->body->content,
+				'slug'    => 'home',
+				'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce680d73300009801731614' )[ 'body' ] )->body->content,
 				'preview' => 'https://via.placeholder.com/200x180',
 			),
-            array(
+			array(
 				'title'   => 'Menu',
-				'slug' 	  => 'menu',
-				'content' => json_decode( file_get_contents( 'http://www.mocky.io/v2/5ce681173300006600731617' ) )->body->content,
+				'slug'    => 'menu',
+				'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681173300006600731617' )[ 'body' ] )->body->content,
 				'preview' => 'https://via.placeholder.com/200x180',
 			),
-            array(
+			array(
 				'title'   => 'Contact Us',
-				'slug' 	  => 'contact',
-				'content' => json_decode( file_get_contents( 'http://www.mocky.io/v2/5ce681763300004b3573161a' ) )->body->content,
+				'slug'    => 'contact',
+				'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681763300004b3573161a' )[ 'body' ] )->body->content,
 				'preview' => 'https://via.placeholder.com/200x180',
 			),
 		),


### PR DESCRIPTION
Fixes #7 and makes us ready to plug in the API once ready.

Test normal plugin functionality. Everything should look and work like before, except template insertion is now instant, skipping a `fetch()` call because we already have all data.

The `json_decode( wp_remote_get( ` hack will only be in place before integrating the real API. In no way it is meant to stay, don't judge me 😄 